### PR TITLE
GRAILS-8330: changed JSON encoding of params attribute to respect List t...

### DIFF
--- a/src/groovy/org/codehaus/groovy/grails/plugins/jquery/JQueryProvider.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/jquery/JQueryProvider.groovy
@@ -23,6 +23,22 @@ import org.codehaus.groovy.grails.plugins.web.taglib.JavascriptProvider
  * @author Finn Herpich (finn.herpich <at> marfinn-software <dot> de)
  */
 class JQueryProvider implements JavascriptProvider {
+
+	/**
+	 * encodeParamValue creates a JSON encoded param
+	 *
+	 * @param value
+	 *
+	 * @return the JSON representation of the value
+	 */
+	def encodeParamValue(value) {
+	    if (value instanceof List) {
+			"[ " + value.collect { encodeParamValue(it) }.join(',') + " ]"
+	    } else {
+			"'" + "$value".encodeAsJavaScript() + "'"
+	    }
+	}
+
 	/**
 	 * doRemoteFunction creates a jQuery-AJAX-Call
 	 *
@@ -67,11 +83,7 @@ class JQueryProvider implements JavascriptProvider {
 				if(attrs?.params instanceof Map) {
 					hasParams = true
 					out << attrs.remove('params').collect { k, v ->
-						"\'" +
-								"${k}".encodeAsJavaScript() +
-								"\': \'" +
-								"${v}".encodeAsJavaScript() +
-								"\'"
+						"'" + "${k}".encodeAsJavaScript() + "': " + encodeParamValue(v)
 					}.join(",")
 				}
 
@@ -80,11 +92,7 @@ class JQueryProvider implements JavascriptProvider {
 						out << ","
 
 					out << attrs.remove('jsParams').collect { k, v ->
-						"\'" +
-								"${k}".encodeAsJavaScript() +
-								"\': \'" +
-								"${v}".encodeAsJavaScript() +
-								"\'"
+						"'" + "${k}".encodeAsJavaScript() + "': " + encodeParamValue(v)
 					}.join(",")
 				}
 


### PR DESCRIPTION
...ype as expected. Please pull it in.

Additionally, it may be useful to add an example to the grails-doc. Because a param added like 't':['1','3'] will be accessible at the controller with brackets only like here: params.list('t[]').

If there is another solution to convert the submitted list so it fits better to the Grails-like syntax params.list('t') please reject this pull request and give a hint where to fix it.

Regards
Michael 
