### PR TITLE
Added support for asset-pipeline inclusion

### DIFF
--- a/grails-app/assets/jquery.js
+++ b/grails-app/assets/jquery.js
@@ -1,0 +1,1 @@
+//=require jquery-${org.codehaus.groovy.grails.plugins.jquery.JQueryConfig.SHIPPED_VERSION}

--- a/grails-app/assets/jquery.js
+++ b/grails-app/assets/jquery.js
@@ -1,1 +1,1 @@
-//=require jquery-${org.codehaus.groovy.grails.plugins.jquery.JQueryConfig.SHIPPED_VERSION}
+//=require jquery/jquery-${org.codehaus.groovy.grails.plugins.jquery.JQueryConfig.SHIPPED_VERSION}


### PR DESCRIPTION
Users of grails asset-pipeline plugin can simply include js into their app.js by doing:

``` javascript
//= require jquery

$(document).ready(function() {
  console.log("Yay! I have jQuery");
});
```
